### PR TITLE
DD-1116: find files in bagstore

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,8 @@ SYNOPSIS
 
 ```bash
 pip3 install easy-migration-tools
-update_thematische_collecties.py < OldThemCol.csv > NewThemCol.csv 
+update_thematische_collecties.py < OldThemCol.csv > NewThemCol.csv
+list-bagstore-files [-p UUID | -d uuids.txt | -d - < uuids.txt] > files.csv 
 ```
 
 DESCRIPTION

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,7 +26,7 @@ beautifulsoup4 = "*"
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.6.15.1"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -102,8 +102,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
@@ -120,8 +120,8 @@ bs4 = [
     {file = "bs4-0.0.1.tar.gz", hash = "sha256:36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+    {file = "certifi-2022.6.15.1-py3-none-any.whl", hash = "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0"},
+    {file = "certifi-2022.6.15.1.tar.gz", hash = "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 update-thematische-collecties = "easymigration.scripts.update_thematische_collecties:main"
+list-bagstore-files = "easymigration.scripts.list_bagstore_files:main"

--- a/src/easymigration/batch_processing.py
+++ b/src/easymigration/batch_processing.py
@@ -1,0 +1,24 @@
+import time
+import logging
+
+
+def batch_process(pids, process_action_func, delay=0.1, fail_on_first_error=True):
+
+    num_pids = len(pids)
+    logging.info("Start batch processing on {} datasets".format(num_pids))
+    num = 0
+    for pid in pids:
+        num += 1
+        logging.info("[{} of {}] Processing dataset with pid: {}".format(num, num_pids, pid))
+        try:
+            process_action_func(pid)
+        except Exception as e:
+            logging.exception("Exception occurred", exc_info=True)
+            if fail_on_first_error:
+                logging.error("Stop processing because of an exception:  {}".format(e))
+                break
+            logging.debug("fail_on_first_error is False, continuing...")
+        if delay > 0 and num < num_pids:
+            logging.debug("Sleeping for {} seconds...".format(delay))
+            time.sleep(delay)
+    logging.info("Done processing {} out of {} datasets".format(num, num_pids))

--- a/src/easymigration/example-easy-migration-tools.yml
+++ b/src/easymigration/example-easy-migration-tools.yml
@@ -1,5 +1,6 @@
 dark_archive:
-  base_url: 'https://localhost:20120/'
+  store_url: 'https://localhost:20110'
+  index_url: 'https://localhost:2012/'
 fedora:
   base_url: 'https://localhost:8080/fedora'
   user_name: 'changeMe'

--- a/src/easymigration/example-easy-migration-tools.yml
+++ b/src/easymigration/example-easy-migration-tools.yml
@@ -1,3 +1,5 @@
+dark_archive:
+  base_url: 'https://localhost:20120/'
 fedora:
   base_url: 'https://localhost:8080/fedora'
   user_name: 'changeMe'

--- a/src/easymigration/example-easy-migration-tools.yml
+++ b/src/easymigration/example-easy-migration-tools.yml
@@ -1,6 +1,6 @@
 dark_archive:
   store_url: 'https://localhost:20110'
-  index_url: 'https://localhost:2012/'
+  index_url: 'https://localhost:20120/'
 fedora:
   base_url: 'https://localhost:8080/fedora'
   user_name: 'changeMe'

--- a/src/easymigration/pids_handling.py
+++ b/src/easymigration/pids_handling.py
@@ -1,0 +1,8 @@
+def load_pids(file_path):
+    # should read from a text file, with each line contains a pid
+    pids = []
+    with open(file_path) as f:
+        pids = f.read().splitlines()
+        # Note that f.readlines() would miss the last 'line' if it has no newline character
+    # trim whitespace and remove empty lines...
+    return list(filter(lambda item: item.strip(), pids))

--- a/src/easymigration/pids_handling.py
+++ b/src/easymigration/pids_handling.py
@@ -19,7 +19,7 @@ def load_pids(file_path):
 
 
 def add_pid_args(parser):
-    pids = parser.add_mutually_exclusive_group(required=True)
+    pids = parser.add_mutually_exclusive_group(required=False)
     pids.add_argument('-p', '--pid', dest='pid',
                       help='The ID of a single dataset')
     pids.add_argument('-d', '--datasets', dest='pid_file',
@@ -27,11 +27,13 @@ def add_pid_args(parser):
 
 
 def process_pids(args, process_action_func, delay=0.1, fail_on_first_error=True):
-    # args is supposed to have the options of add_pid_args
     if args.pid is not None:
         process_action_func(args.pid)
-    else:
+    elif args.pid_file is not None:
         batch_process(load_pids(args.pid_file),
                       lambda pid: process_action_func(pid),
                       delay,
                       fail_on_first_error)
+    else:
+        raise Exception("ArgumentParser did not require exactly one of the destinations "
+                        f"'pid' or 'pid_file', see for example add_pid_args")

--- a/src/easymigration/pids_handling.py
+++ b/src/easymigration/pids_handling.py
@@ -2,6 +2,7 @@ from sys import stdin
 
 from easymigration.batch_processing import batch_process
 
+
 def non_empty_lines(file_content):
     # Note that f.readlines() would miss the last 'line' if it has no newline character
     # trim whitespace and remove empty lines...
@@ -11,7 +12,6 @@ def non_empty_lines(file_content):
 def load_pids(file_path):
     # should read from a text file, with each line contains a pid
     # Note that readlines() would miss the last 'line' if it has no newline character
-    pids = []
     if file_path == "-":
         pids = stdin.read()
     else:
@@ -20,8 +20,19 @@ def load_pids(file_path):
 
 
 def add_pid_args(parser):
-    pid_or_file = parser.add_mutually_exclusive_group()
-    pid_or_file.add_argument('-p', '--pid', dest='pid',
-                             help='The pid of a dataset.')
-    pid_or_file.add_argument('-d', '--datasets', dest='pid_file',
-                             help='The input file with the dataset pids (UUIDs)')
+    pids = parser.add_mutually_exclusive_group(required=True)
+    pids.add_argument('-p', '--pid', dest='pid',
+                      help='The pid of a dataset.')
+    pids.add_argument('-d', '--datasets', dest='pid_file',
+                      help='The input file with the dataset pids, "-" is stdin')
+
+
+def process_pids(args, process_action_func, delay=0.1, fail_on_first_error=True):
+    # args is supposed to have the options of add_pid_args
+    if args.pid is not None:
+        process_action_func(args.pid)
+    else:
+        batch_process(load_pids(args.pid_file),
+                      lambda pid: process_action_func(pid),
+                      delay,
+                      fail_on_first_error)

--- a/src/easymigration/pids_handling.py
+++ b/src/easymigration/pids_handling.py
@@ -1,8 +1,4 @@
-def load_pids(file_path):
-    # should read from a text file, with each line contains a pid
-    pids = []
-    with open(file_path) as f:
-        pids = f.read().splitlines()
-        # Note that f.readlines() would miss the last 'line' if it has no newline character
+def non_empty_lines(file_content):
+    # Note that f.readlines() would miss the last 'line' if it has no newline character
     # trim whitespace and remove empty lines...
-    return list(filter(lambda item: item.strip(), pids))
+    return list(filter(lambda item: item.strip(), file_content.splitlines()))

--- a/src/easymigration/pids_handling.py
+++ b/src/easymigration/pids_handling.py
@@ -1,4 +1,27 @@
+from sys import stdin
+
+from easymigration.batch_processing import batch_process
+
 def non_empty_lines(file_content):
     # Note that f.readlines() would miss the last 'line' if it has no newline character
     # trim whitespace and remove empty lines...
     return list(filter(lambda item: item.strip(), file_content.splitlines()))
+
+
+def load_pids(file_path):
+    # should read from a text file, with each line contains a pid
+    # Note that readlines() would miss the last 'line' if it has no newline character
+    pids = []
+    if file_path == "-":
+        pids = stdin.read()
+    else:
+        pids = open(file_path).read()
+    return non_empty_lines(pids)
+
+
+def add_pid_args(parser):
+    pid_or_file = parser.add_mutually_exclusive_group()
+    pid_or_file.add_argument('-p', '--pid', dest='pid',
+                             help='The pid of a dataset.')
+    pid_or_file.add_argument('-d', '--datasets', dest='pid_file',
+                             help='The input file with the dataset pids (UUIDs)')

--- a/src/easymigration/pids_handling.py
+++ b/src/easymigration/pids_handling.py
@@ -4,14 +4,13 @@ from easymigration.batch_processing import batch_process
 
 
 def non_empty_lines(file_content):
-    # Note that f.readlines() would miss the last 'line' if it has no newline character
+    # Note that readlines() would miss the last 'line' if it has no newline character
     # trim whitespace and remove empty lines...
     return list(filter(lambda item: item.strip(), file_content.splitlines()))
 
 
 def load_pids(file_path):
     # should read from a text file, with each line contains a pid
-    # Note that readlines() would miss the last 'line' if it has no newline character
     if file_path == "-":
         pids = stdin.read()
     else:
@@ -22,9 +21,9 @@ def load_pids(file_path):
 def add_pid_args(parser):
     pids = parser.add_mutually_exclusive_group(required=True)
     pids.add_argument('-p', '--pid', dest='pid',
-                      help='The pid of a dataset.')
+                      help='The ID of a single dataset')
     pids.add_argument('-d', '--datasets', dest='pid_file',
-                      help='The input file with the dataset pids, "-" is stdin')
+                      help='Newline separated file with dataset IDs, "-" is stdin')
 
 
 def process_pids(args, process_action_func, delay=0.1, fail_on_first_error=True):

--- a/src/easymigration/pids_handling.py
+++ b/src/easymigration/pids_handling.py
@@ -19,7 +19,7 @@ def load_pids(file_path):
 
 
 def add_pid_args(parser):
-    pids = parser.add_mutually_exclusive_group(required=False)
+    pids = parser.add_mutually_exclusive_group(required=True)
     pids.add_argument('-p', '--pid', dest='pid',
                       help='The ID of a single dataset')
     pids.add_argument('-d', '--datasets', dest='pid_file',
@@ -35,5 +35,5 @@ def process_pids(args, process_action_func, delay=0.1, fail_on_first_error=True)
                       delay,
                       fail_on_first_error)
     else:
-        raise Exception("ArgumentParser did not require exactly one of the destinations "
-                        f"'pid' or 'pid_file', see for example add_pid_args")
+        raise Exception("Programming error: ArgumentParser did not require exactly one of the 'dest'-s  "
+                        "'pid' or 'pid_file', please call add_pid_args or an equivalent")

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -1,0 +1,88 @@
+# given a doi, retrieve the uuid and subsequently the files from the bag-store
+
+import argparse
+import csv
+import logging
+import sys
+
+import requests
+from xml.dom import minidom
+from easymigration.batch_processing import batch_process
+from easymigration.config import init
+from easymigration.pids_handling import load_pids
+
+
+def find_files(doi, dark_url, csv_writer):
+    uuid = find_uuid(doi, dark_url)
+    files_xml = get_files_xml(uuid, dark_url)
+    parse_files_xml(doi, files_xml, csv_writer)
+
+
+def find_uuid(doi, bag_index_url):
+    #locate in bag-index
+    try:
+        params = {'doi': doi}
+        response = requests.put(
+            bag_index_url + '/bag-index/search',
+            params=params)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as re:
+        print("RequestException: ", re)
+        raise
+    resp_data = response.json()['result'][0]["bag-info"]["urn"]
+    return resp_data
+
+
+def get_files_xml(urn, bag_store_url):
+    try:
+        url = "{}/bag-store/bags/{}/metadata/files.xml".format(bag_store_url, urn)
+        logging.debug(url)
+        response = requests.put(url)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as re:
+        print("RequestException: ", re)
+        raise
+    return response
+
+
+def parse_files_xml(doi, files_xml, csv_writer):
+    mydoc = minidom.parse(files_xml)
+
+    file_items = mydoc.getElementsByTagName('file')
+    for elem in file_items:
+        access = elem.getElementsByTagName('accessibleToRights')
+        access_text = ''
+        if access is not None and len(access) == 1:
+            access_text = access[0].firstChild.nodeValue
+        row = {"doi": doi, "path": elem.attributes['filepath'].value, "accessCategory": access_text}
+        csv_writer.writerow(row)
+
+
+def main():
+    config = init()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description='For each doi, list the files in the bag-store'
+    )
+    pid_or_file = parser.add_mutually_exclusive_group()
+    pid_or_file.add_argument('-p', '--pid', dest='pid', help='Pid of a single dataset for which to find the files')
+    pid_or_file.add_argument('-d', '--datasets', dest='pid_file', help='The input file with the dataset pids')
+    args = parser.parse_args()
+
+    dark_url = config['dark_archive']['base_url']
+
+    fieldnames = {"doi", "path", "accessCategory"}
+    csv_writer = csv.DictWriter(sys.stdout, delimiter=',', fieldnames=fieldnames)
+    csv_writer.writeheader()
+
+    if args.pid is not None:
+        find_files(args.pid, dark_url, csv_writer)
+
+    if args.pid_file is not None:
+        pids = load_pids(args.pid_file)
+        batch_process(pids,
+                      lambda pid: find_files(pid, dark_url, csv_writer))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -17,25 +17,14 @@ def find_files(uuid, dark_archive, csv_writer):
     store_url = dark_archive["store_url"]
     metadata_url = f"{store_url}/bags/{uuid}/metadata"
     files_xml = get_file(f"{metadata_url}/files.xml")
-    if (files_xml):
+    if files_xml:
         ddm = get_file(f"{metadata_url}/dataset.xml")
-        if (ddm):
+        if ddm:
             doi = find_doi(ddm)
             if doi:
                 parse_files_xml(uuid, doi, files_xml, csv_writer)
             else:
                 logging.error(f"No DOI found for {uuid}")
-
-
-def find_uuid(doi, bag_index_url):
-    # locate in bag-index
-    response = requests.get(f"{bag_index_url}/search", params={"doi": doi})
-    if response.status_code == 404:
-        logging.error(f"{doi} not available: {response.status_code}")
-        return ""
-    elif response.status_code != 200:
-        raise Exception(f"{doi}: {response.status_code}")
-    return response.json()["result"][0]["bag-info"]["bag-id"]
 
 
 def get_file(url):
@@ -53,10 +42,9 @@ def get_file(url):
 def find_doi(ddm):
     identifier_items = minidom.parseString(ddm).getElementsByTagNameNS("http://purl.org/dc/terms/", "identifier")
     for elem in identifier_items:
-        logging.debug(elem)
-        type = elem.getAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "type")
-        logging.debug(f"type = {type}")
-        if type == "id-type:DOI":
+        id_type = elem.getAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "type")
+        logging.debug(f"type = {id_type}")
+        if id_type == "id-type:DOI":
             return elem.firstChild.nodeValue
     return ""
 

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -12,49 +12,46 @@ from easymigration.config import init
 from easymigration.pids_handling import non_empty_lines
 
 
-def find_files(doi, dark_url, csv_writer):
-    uuid = find_uuid(doi, dark_url)
-    files_xml = get_files_xml(uuid, dark_url)
+def find_files(doi, dark_archive, csv_writer):
+    # TODO continue batch if not found
+    uuid = find_uuid(doi, dark_archive["index_url"])
+    files_xml = get_files_xml(uuid, dark_archive["store_url"])
     parse_files_xml(doi, files_xml, csv_writer)
 
 
 def find_uuid(doi, bag_index_url):
     # locate in bag-index
     try:
-        params = {'doi': doi}
-        response = requests.get(
-            bag_index_url + 'search',
-            params=params)
+        params = {"doi": doi}
+        response = requests.get(f"{bag_index_url}/search", params=params)
         response.raise_for_status()
     except requests.exceptions.RequestException as re:
-        print("RequestException: ", re)
+        logging.error("RequestException: ", re)
         raise
-    resp_data = response.json()['result'][0]["bag-info"]["urn"]
+    resp_data = response.json()["result"][0]["bag-info"]["bag-id"]
     return resp_data
 
 
-def get_files_xml(urn, bag_store_url):
+def get_files_xml(uuid, bag_store_url):
     try:
-        url = "{}/bag-store/bags/{}/metadata/files.xml".format(bag_store_url, urn)
+        url = f"{bag_store_url}/bags/{uuid}/metadata/files.xml"
         logging.debug(url)
-        response = requests.put(url)
+        response = requests.get(url)
         response.raise_for_status()
     except requests.exceptions.RequestException as re:
-        print("RequestException: ", re)
+        logging.error("RequestException: ", re)
         raise
-    return response
+    return response.text
 
 
 def parse_files_xml(doi, files_xml, csv_writer):
-    mydoc = minidom.parse(files_xml)
-
-    file_items = mydoc.getElementsByTagName('file')
+    file_items = minidom.parseString(files_xml).getElementsByTagName("file")
     for elem in file_items:
-        access = elem.getElementsByTagName('accessibleToRights')
-        access_text = ''
+        access = elem.getElementsByTagName("accessibleToRights")
+        access_text = ""
         if access is not None and len(access) == 1:
             access_text = access[0].firstChild.nodeValue
-        row = {"doi": doi, "path": elem.attributes['filepath'].value, "accessCategory": access_text}
+        row = {"doi": doi, "path": elem.attributes["filepath"].value, "accessCategory": access_text}
         csv_writer.writerow(row)
 
 
@@ -62,26 +59,26 @@ def main():
     config = init()
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description='For each doi, list the files in the bag-store'
+        description="For each doi, list the files in the bag-store"
     )
-    parser.add_argument('-d', '--doi', dest='doi',
-                        help='Pid of a single dataset for which to find the files. '
-                             'When omitted, DOIs are read from stdin.')
+    parser.add_argument("-d", "--doi", dest="doi",
+                        help="Pid of a single dataset for which to find the files. "
+                             "When omitted, DOIs are read from stdin.")
     args = parser.parse_args()
 
-    dark_url = config['dark_archive']['base_url']
+    dark_archive = config["dark_archive"]
 
     fieldnames = {"doi", "path", "accessCategory"}
-    csv_writer = csv.DictWriter(sys.stdout, delimiter=',', fieldnames=fieldnames)
+    csv_writer = csv.DictWriter(sys.stdout, delimiter=",", fieldnames=fieldnames)
     csv_writer.writeheader()
 
     if args.doi is not None:
-        find_files(args.doi, dark_url, csv_writer)
+        find_files(args.doi, dark_archive, csv_writer)
     else:
         dois = non_empty_lines(sys.stdin.read())
         batch_process(dois,
-                      lambda doi: find_files(doi, dark_url, csv_writer))
+                      lambda doi: find_files(doi, dark_archive, csv_writer))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -9,7 +9,7 @@ import requests
 from xml.dom import minidom
 from easymigration.batch_processing import batch_process
 from easymigration.config import init
-from easymigration.pids_handling import non_empty_lines
+from easymigration.pids_handling import load_pids, add_pid_args, non_empty_lines
 
 
 def find_files(bag_store_url, uuid, csv_writer):
@@ -64,11 +64,7 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="For each UUID, list the files in the bag-store"
     )
-    pid_or_file = parser.add_mutually_exclusive_group()
-    pid_or_file.add_argument('-p', '--pid', dest='pid',
-                             help='Pid (UUID) of a single dataset for which to find the files.')
-    pid_or_file.add_argument('-d', '--datasets', dest='pid_file',
-                             help='The input file with the dataset pids (UUIDs)')
+    add_pid_args(parser)
     args = parser.parse_args()
 
     fieldnames = ["uuid", "doi", "path", "accessCategory"]
@@ -79,7 +75,7 @@ def main():
     if args.pid is not None:
         find_files(bag_store_url, args.pid, csv_writer)
     else:
-        pids = non_empty_lines(sys.stdin.read())
+        pids = load_pids(args.pid_file)
         batch_process(pids,
                       lambda pid: find_files(bag_store_url, pid, csv_writer))
 

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -1,4 +1,4 @@
-# given a doi, retrieve the uuid and subsequently the files from the bag-store
+# given a UUID, retrieve the DOI and subsequently the files from the bag-store
 
 import argparse
 import csv

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -12,46 +12,63 @@ from easymigration.config import init
 from easymigration.pids_handling import non_empty_lines
 
 
-def find_files(doi, dark_archive, csv_writer):
-    # TODO continue batch if not found
-    uuid = find_uuid(doi, dark_archive["index_url"])
-    logging.debug(f"DOI = {doi}; UUID={uuid}")
-    if uuid:
-        files_xml = get_files_xml(uuid, dark_archive["store_url"])
-        if (files_xml):
-            parse_files_xml(doi, files_xml, csv_writer)
+def find_files(uuid, dark_archive, csv_writer):
+    logging.debug(uuid)
+    store_url = dark_archive["store_url"]
+    metadata_url = f"{store_url}/bags/{uuid}/metadata"
+    files_xml = get_file(f"{metadata_url}/files.xml")
+    if (files_xml):
+        ddm = get_file(f"{metadata_url}/dataset.xml")
+        if (ddm):
+            doi = find_doi(ddm)
+            if doi:
+                parse_files_xml(uuid, doi, files_xml, csv_writer)
+            else:
+                logging.error(f"No DOI found for {uuid}")
 
 
 def find_uuid(doi, bag_index_url):
     # locate in bag-index
     response = requests.get(f"{bag_index_url}/search", params={"doi": doi})
     if response.status_code == 404:
-        logging.error(f"${doi} not available: {response.status_code}")
+        logging.error(f"{doi} not available: {response.status_code}")
         return ""
     elif response.status_code != 200:
-        raise Exception(f"${doi}: ${response.status_code}")
+        raise Exception(f"{doi}: {response.status_code}")
     return response.json()["result"][0]["bag-info"]["bag-id"]
 
 
-def get_files_xml(uuid, bag_store_url):
-    response = requests.get(f"{bag_store_url}/bags/{uuid}/metadata/files.xml")
-    if response.status_code == 410:
-        logging.error(f"Files for {uuid} not available: {response.status_code}")
+def get_file(url):
+    logging.debug(url)
+    response = requests.get(url)
+    if response.status_code == 410 or response.status_code == 404:
+        logging.error(f"Not found {response.status_code} : {url}")
         return ""
     elif response.status_code != 200:
-        raise Exception(f"${uuid}: ${response.status_code}")
+        raise Exception(f"status {response.status_code} : {url}")
     else:
         return response.text
 
 
-def parse_files_xml(doi, files_xml, csv_writer):
+def find_doi(ddm):
+    identifier_items = minidom.parseString(ddm).getElementsByTagNameNS("http://purl.org/dc/terms/", "identifier")
+    for elem in identifier_items:
+        logging.debug(elem)
+        type = elem.getAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "type")
+        logging.debug(f"type = {type}")
+        if type == "id-type:DOI":
+            return elem.firstChild.nodeValue
+    return ""
+
+
+def parse_files_xml(uuid, doi, files_xml, csv_writer):
     file_items = minidom.parseString(files_xml).getElementsByTagName("file")
     for elem in file_items:
         access = elem.getElementsByTagName("accessibleToRights")
         access_text = ""
         if access is not None and len(access) == 1:
             access_text = access[0].firstChild.nodeValue
-        row = {"doi": doi, "path": elem.attributes["filepath"].value, "accessCategory": access_text}
+        row = {"uuid": uuid, "doi": doi, "path": elem.attributes["filepath"].value, "accessCategory": access_text}
         csv_writer.writerow(row)
 
 
@@ -61,23 +78,23 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="For each doi, list the files in the bag-store"
     )
-    parser.add_argument("-d", "--doi", dest="doi",
-                        help="Pid of a single dataset for which to find the files. "
-                             "When omitted, DOIs are read from stdin.")
+    parser.add_argument("-p", dest="pid",
+                        help="UUID of a bag for which to find the files. "
+                             "When omitted, UUIDs are read from stdin.")
     args = parser.parse_args()
 
     dark_archive = config["dark_archive"]
 
-    fieldnames = {"doi", "path", "accessCategory"}
+    fieldnames = {"uuid", "doi", "path", "accessCategory"}
     csv_writer = csv.DictWriter(sys.stdout, delimiter=",", fieldnames=fieldnames)
     csv_writer.writeheader()
 
-    if args.doi is not None:
-        find_files(args.doi, dark_archive, csv_writer)
+    if args.pid is not None:
+        find_files(args.pid, dark_archive, csv_writer)
     else:
-        dois = non_empty_lines(sys.stdin.read())
-        batch_process(dois,
-                      lambda doi: find_files(doi, dark_archive, csv_writer))
+        pids = non_empty_lines(sys.stdin.read())
+        batch_process(pids,
+                      lambda pid: find_files(pid, dark_archive, csv_writer))
 
 
 if __name__ == "__main__":

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -15,33 +15,33 @@ from easymigration.pids_handling import non_empty_lines
 def find_files(doi, dark_archive, csv_writer):
     # TODO continue batch if not found
     uuid = find_uuid(doi, dark_archive["index_url"])
-    files_xml = get_files_xml(uuid, dark_archive["store_url"])
-    parse_files_xml(doi, files_xml, csv_writer)
+    logging.debug(f"DOI = {doi}; UUID={uuid}")
+    if uuid:
+        files_xml = get_files_xml(uuid, dark_archive["store_url"])
+        if (files_xml):
+            parse_files_xml(doi, files_xml, csv_writer)
 
 
 def find_uuid(doi, bag_index_url):
     # locate in bag-index
-    try:
-        params = {"doi": doi}
-        response = requests.get(f"{bag_index_url}/search", params=params)
-        response.raise_for_status()
-    except requests.exceptions.RequestException as re:
-        logging.error("RequestException: ", re)
-        raise
-    resp_data = response.json()["result"][0]["bag-info"]["bag-id"]
-    return resp_data
+    response = requests.get(f"{bag_index_url}/search", params={"doi": doi})
+    if response.status_code == 404:
+        logging.error(f"${doi} not available: {response.status_code}")
+        return ""
+    elif response.status_code != 200:
+        raise Exception(f"${doi}: ${response.status_code}")
+    return response.json()["result"][0]["bag-info"]["bag-id"]
 
 
 def get_files_xml(uuid, bag_store_url):
-    try:
-        url = f"{bag_store_url}/bags/{uuid}/metadata/files.xml"
-        logging.debug(url)
-        response = requests.get(url)
-        response.raise_for_status()
-    except requests.exceptions.RequestException as re:
-        logging.error("RequestException: ", re)
-        raise
-    return response.text
+    response = requests.get(f"{bag_store_url}/bags/{uuid}/metadata/files.xml")
+    if response.status_code == 410:
+        logging.error(f"Files for {uuid} not available: {response.status_code}")
+        return ""
+    elif response.status_code != 200:
+        raise Exception(f"${uuid}: ${response.status_code}")
+    else:
+        return response.text
 
 
 def parse_files_xml(doi, files_xml, csv_writer):

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -9,7 +9,7 @@ import requests
 from xml.dom import minidom
 from easymigration.batch_processing import batch_process
 from easymigration.config import init
-from easymigration.pids_handling import load_pids, add_pid_args, non_empty_lines
+from easymigration.pids_handling import load_pids, add_pid_args, non_empty_lines, process_pids
 
 
 def find_files(bag_store_url, uuid, csv_writer):
@@ -60,24 +60,20 @@ def parse_files_xml(uuid, doi, files_xml, csv_writer):
 
 def main():
     config = init()
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description="For each UUID, list the files in the bag-store"
-    )
-    add_pid_args(parser)
-    args = parser.parse_args()
 
     fieldnames = ["uuid", "doi", "path", "accessCategory"]
     csv_writer = csv.DictWriter(sys.stdout, delimiter=",", fieldnames=fieldnames)
     csv_writer.writeheader()
 
     bag_store_url = config["dark_archive"]["store_url"]
-    if args.pid is not None:
-        find_files(bag_store_url, args.pid, csv_writer)
-    else:
-        pids = load_pids(args.pid_file)
-        batch_process(pids,
-                      lambda pid: find_files(bag_store_url, pid, csv_writer))
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="For each UUID, list the files in the bag-store"
+    )
+    add_pid_args(parser)
+    args = parser.parse_args()
+    process_pids(args, lambda pid: find_files(bag_store_url, pid, csv_writer))
 
 
 if __name__ == "__main__":

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -58,21 +58,24 @@ def parse_files_xml(uuid, doi, files_xml, csv_writer):
         csv_writer.writerow(row)
 
 
-def main():
-    config = init()
-
+def create_csv():
     fieldnames = ["uuid", "doi", "path", "accessCategory"]
     csv_writer = csv.DictWriter(sys.stdout, delimiter=",", fieldnames=fieldnames)
     csv_writer.writeheader()
+    return csv_writer
 
+
+def main():
+    config = init()
     bag_store_url = config["dark_archive"]["store_url"]
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description="For each UUID, list the files in the bag-store"
+        description="For each dataset (identified with a UUID), list the files in the bag-store"
     )
     add_pid_args(parser)
     args = parser.parse_args()
+    csv_writer = create_csv() # after parsing to avoid output on --help
     process_pids(args, lambda pid: find_files(bag_store_url, pid, csv_writer))
 
 

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -35,7 +35,7 @@ def get_file(url):
 
 def find_ids(ddm):
     if not ddm:
-        return ["",""]
+        return ["", ""]
     ns = "http://purl.org/dc/terms/"
     items = minidom.parseString(ddm).getElementsByTagNameNS(ns, "identifier")
     id_strings = sorted(map(child_value, filter(is_id, items)))
@@ -43,7 +43,7 @@ def find_ids(ddm):
         return id_strings
     else:
         logging.error(f"Expecting [DOI,easy-dataset:NN]. Found {','.join(id_strings)}")
-        return ["",""]
+        return ["", ""]
 
 
 def child_value(elem):
@@ -52,9 +52,8 @@ def child_value(elem):
 
 def is_id(id_elem):
     ns = "http://www.w3.org/2001/XMLSchema-instance"
-    is_doi = id_elem.getAttributeNS(ns, "type") == "id-type:DOI"
-    is_dataset_id = id_elem.hasAttributeNS(ns, "type")
-    return is_doi or not is_dataset_id
+    is_dataset_id = child_value(id_elem).startswith('easy-dataset:')
+    return is_dataset_id or id_elem.getAttributeNS(ns, "type") == "id-type:DOI"
 
 
 def parse_files_xml(uuid, ids, files_xml, csv_writer):

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -75,7 +75,7 @@ def main():
     )
     add_pid_args(parser)
     args = parser.parse_args()
-    csv_writer = create_csv() # after parsing to avoid output on --help
+    csv_writer = create_csv()  # after parsing to avoid output on --help
     process_pids(args, lambda pid: find_files(bag_store_url, pid, csv_writer))
 
 

--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -4,12 +4,12 @@ import argparse
 import csv
 import logging
 import sys
+from xml.dom import minidom
 
 import requests
-from xml.dom import minidom
-from easymigration.batch_processing import batch_process
+
 from easymigration.config import init
-from easymigration.pids_handling import load_pids, add_pid_args, non_empty_lines, process_pids
+from easymigration.pids_handling import add_pid_args, process_pids
 
 
 def find_files(bag_store_url, uuid, csv_writer):


### PR DESCRIPTION
Fixes DD-1116: find files in bagstore

# Description of changes

# How to test
with a running deasy VM

    cd ~/git/service/easy/easy-sword2-dans-examples
    ./run.sh Simple https://deasy.dans.knaw.nl/sword2/collection/1 IPDBSTest IPDBSTest src/main/resources/agreement-flow/valid/file-accessibilities
    cd ~/git/service/easy/easy-migration-tools
    poetry run list-bagstore-files -d data/uuids.txt > data/files.csv

Check also error logs for
* [x] inactive bags (response code 410)
* [x] bags that don't exist  (response code 404)

result:

```csv
uuid,doi,dataset-id,path,accessCategory
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/random images/image01.png,
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/random images/image02.jpeg,
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/random images/image03.jpeg,
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/a/deeper/path/With some file.txt,
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/accessibilities/anonymous.txt,ANONYMOUS
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/accessibilities/known.txt,KNOWN
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/accessibilities/request.txt,RESTRICTED_REQUEST
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/visibilities/anonymous.txt,
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/visibilities/known.txt,
7f2b90d7-7e56-4ad4-a298-4474aa6c1938,10.80270/test-xztF-xeh-dxup,easy-dataset:32,data/visibilities/none.txt,
```


# Related PRs

replaces #3 

*

# Notify

@DANS-KNAW/dataversedans
