### PR TITLE
DD-1188: convert encoding incorrectly stored like <E2><80><93>

### DIFF
--- a/src/easymigration/scripts/list_bagstore_files.py
+++ b/src/easymigration/scripts/list_bagstore_files.py
@@ -44,9 +44,7 @@ def convert_encoding(str):
     b3 = f"<[eE]{d}>{dd}{dd}"
     b4 = f"<[fF]{d}>{dd}{dd}{dd}"
     regexp = f"(?s)(({b2})|({b3})|({b4}))"
-    converted = re.sub(regexp, convert_encoding_match, str)
-    logging.debug(converted)
-    return converted
+    return re.sub(regexp, convert_encoding_match, str)
 
 
 def convert_encoding_match(match_obj):


### PR DESCRIPTION
Fixes DD-1188: convert encoding incorrectly stored like <E2><80><93>

# Description of changes

# How to test

tested with a temporary extra code line which produced a higher wider dash

    logging.debug(convert_encoding('  <file filepath="data/2009-152_Wijchen <E2><80><93> Alverna G, Huurlingsedam.pdf">'))

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
